### PR TITLE
Install cover-codecov in the example .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.1.1
-    - RACKET_VERSION=6.2
-    - RACKET_VERSION=6.2.1
-    - RACKET_VERSION=6.3
-    - RACKET_VERSION=6.4
+    - RACKET_VERSION=6.6
+    - RACKET_VERSION=6.7
     - RACKET_VERSION=HEAD
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ script:
   - raco test $TRAVIS_BUILD_DIR # run tests. you wrote tests, right?
 
 after_success:
+  - raco pkg install --deps search-auto cover cover-codecov
   - raco cover -f codecov -d $TRAVIS_BUILD_DIR/coverage . # generate coverage information for coveralls
 ```
 The above Travis configuration will install any project dependencies, test your project, and report coverage information to Codecov.


### PR DESCRIPTION
I don't think `cover-codecov` comes with the main distribution, so the example .travis.yml file in the README should include the command to install it.