### PR TITLE
Add CircleCI support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+Spencer Florence
+Ryan Plessner
+Google Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright © 2015 Spencer Florence and Ryan Plessner
+Copyright © 2018 The codecov-racket Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ cover:
 
 ## Use with CircleCI
 
+*added in version 0.2.0*
+
 CircleCI is (mostly) based on Docker, so you'll have to choose a Docker image to
 use as your base Racket installation. Then in your `.circleci/config.yml`
 configuration run the same cover commands as the Travis and Gitlab examples:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ cover:
     - raco cover -f codecov $CI_PROJECT_DIR
 ```
 
-
 ## Use with CircleCI
 
 *added in version 0.2.0*

--- a/README.md
+++ b/README.md
@@ -107,6 +107,6 @@ jobs:
           name: Cover
           command: raco cover -f codecov -p my-package
           environment:
-            COVER_TOKEN: ... # your codecov project UUID token
-            COVER_ACCESS_TOKEN: ... # API token, only needed for private repos
+            CODECOV_TOKEN: ... # your codecov project UUID token
+            CODECOV_ACCESS_TOKEN: ... # API token, only needed for private repos
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 Adds [Codecov](https://codecov.io/) support to [Cover](https://github.com/florence/cover).
 
-_Note_:  The currently supported methods of posting data to [Codecov](https://codecov.io/) are [Travis CI](https://travis-ci.org/) and [Gitlab CI](https://about.gitlab.com/gitlab-ci/).
+_Note_:  The currently supported methods of posting data to [Codecov](https://codecov.io/) are [Travis CI](https://travis-ci.org/), [Gitlab CI](https://about.gitlab.com/gitlab-ci/),
+and [Circle CI](https://circleci.com/).
 
 ## Use with Travis CI
 First enable your repository on Travis and Codecov.
@@ -74,4 +75,37 @@ cover:
   script:
     - raco pkg install --auto cover cover-codecov
     - raco cover -f codecov $CI_PROJECT_DIR
+```
+
+
+## Use with CircleCI
+
+CircleCI is (mostly) based on Docker, so you'll have to choose a Docker image to
+use as your base Racket installation. Then in your `.circleci/config.yml`
+configuration run the same cover commands as the Travis and Gitlab examples:
+
+```yml
+version: 2
+jobs:
+  build:
+    docker:
+      - image: jackfirth/racket:6.12 # or build your own image
+    steps:
+      - checkout
+      - run:
+          name: Install
+          # install working directory (which is the repo root) as a package
+          command: raco pkg install --auto --link --name my-package
+      - run:
+          name: Test
+          command: raco test -p my-package
+      - run:
+          name: Install Cover
+          command: raco pkg install --auto cover cover-codecov
+      - run:
+          name: Cover
+          command: raco cover -f codecov -p my-package
+          environment:
+            COVER_TOKEN: ... # your codecov project UUID token
+            COVER_ACCESS_TOKEN: ... # API token, only needed for private repos
 ```

--- a/cover/private/circle-service.rkt
+++ b/cover/private/circle-service.rkt
@@ -1,0 +1,48 @@
+#lang racket/base
+
+;; CODECOV_TOKEN - project identifier
+;; CODECOV_ACCESS_TOKEN - for private repositories
+;; CODECOV_UPLOAD_NAME - for giving a coverage report a custom name
+;; CODECOV_COVERAGE_FLAGS - for coverage flags, see codecov docs at
+;;   https://docs.codecov.io/v4.3.6/docs/flags
+
+(provide circle-service@ circle-ci?)
+
+(require "ci-service.rkt" racket/unit racket/list racket/string)
+
+(define (circle-ci?) (and (getenv "CI") (getenv "CIRCLECI")))
+
+(define-unit circle-service@
+  (import)
+  (export ci-service^)
+
+  (define (query)
+    ;; codecov query param docs: https://docs.codecov.io/v4.3.6/reference#upload
+    ;; circleci env docs: https://circleci.com/docs/2.0/env-vars/#circleci-built-in-environment-variables
+    (list (cons 'commit (getenv/log-when-missing "CIRCLE_SHA1"))
+          (cons 'token (getenv/log-when-missing "CODECOV_TOKEN"))
+          (cons 'access_token (getenv "CODECOV_ACCESS_TOKEN"))
+          (cons 'branch (getenv/log-when-missing "CIRCLE_BRANCH"))
+          (cons 'build (getenv/log-when-missing "CIRCLE_BUILD_NUM"))
+          (cons 'job (getenv/log-when-missing "CIRCLE_NODE_INDEX"))
+          (cons 'build_url (getenv/log-when-missing "CIRCLE_BUILD_URL"))
+          (cons 'name (getenv "CODECOV_UPLOAD_NAME"))
+          (cons 'slug (get-circle-slug-env))
+          (cons 'service "circleci")
+          (cons 'flags (getenv "CODECOV_COVERAGE_FLAGS"))
+          (cons 'pr (getenv "CIRCLE_PR_NUMBER")))))
+
+(define (get-circle-slug-env)
+  (define user-part (getenv/log-when-missing "CIRCLE_PROJECT_USERNAME"))
+  (define repo-part (getenv/log-when-missing "CIRCLE_PROJECT_REPONAME"))
+  (and user-part repo-part (format "~a/~a" user-part repo-part)))
+
+;; logger name chosen to identify the source collection module
+(define-logger cover/private/circle-service)
+
+(define (getenv/log-when-missing env)
+  (define env-value (getenv env))
+  (unless env-value
+    (log-cover/private/circle-service-warning
+     "unexpectedly missing environment variable: ~a" env))
+  env-value)

--- a/cover/private/codecov.rkt
+++ b/cover/private/codecov.rkt
@@ -12,7 +12,8 @@
   cover/private/file-utils
   "ci-service.rkt"
   "travis-service.rkt"
-  "gitlab-service.rkt")
+  "gitlab-service.rkt"
+  "circle-service.rkt")
 
 (module+ test
   (require rackunit cover racket/runtime-path))
@@ -75,7 +76,8 @@
 
 (define services
   (hash travis-ci? travis-service@
-        gitlab-ci? gitlab-service@))
+        gitlab-ci? gitlab-service@
+        circle-ci? circle-service@))
 
 (define CODECOV_HOST "codecov.io")
 

--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,7 @@
 (define name "cover-codecov")
 (define collection 'multi)
 
-(define version "0.1.1")
+(define version "0.2.0")
 
 (define deps '(
   ("base" #:version "6.1.1")


### PR DESCRIPTION
Closes #4 

Additionally, this PR adds an AUTHORS file listing copyright holders and adds Google Inc. to that file. Due to my employer agreement, open source patches I author are copyright Google. This doesn't affect the project's MIT license beyond adding "Google Inc." as a copyright holder instead of "Jack Firth".

This PR introduces a `CODECOV_ACCESS_TOKEN` environment variable for submitting private repository coverage reports to Codecov, but only uses it in the CircleCI service.