### PR TITLE
Add support GitHub CI (Actions / Workflows)

### DIFF
--- a/cover/private/codecov.rkt
+++ b/cover/private/codecov.rkt
@@ -12,7 +12,8 @@
   cover/private/file-utils
   "ci-service.rkt"
   "travis-service.rkt"
-  "gitlab-service.rkt")
+  "gitlab-service.rkt"
+  "github-service.rkt")
 
 (module+ test
   (require rackunit cover racket/runtime-path))
@@ -75,7 +76,8 @@
 
 (define services
   (hash travis-ci? travis-service@
-        gitlab-ci? gitlab-service@))
+        gitlab-ci? gitlab-service@
+        github-ci? github-service@))
 
 (define CODECOV_HOST "codecov.io")
 

--- a/cover/private/github-service.rkt
+++ b/cover/private/github-service.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
-(provide github-service@ github-env?)
+(provide github-service@ github-ci?)
 
 (require "ci-service.rkt" racket/unit racket/list racket/string)
 

--- a/cover/private/github-service.rkt
+++ b/cover/private/github-service.rkt
@@ -14,7 +14,7 @@
     (list (cons 'service "custom")
           (cons 'token (getenv "CODECOV_TOKEN"))
           ;; TODO: this won't work for tags
-          (cons 'branch (substring (getenv "GITHUB_REF") (string-length "refs/heads/")))
+          (cons 'branch (string-trim (getenv "GITHUB_REF") #px"refs/(heads|tags)/"))
           (cons 'job (getenv "GITHUB_JOB"))
           (cons 'slug (getenv "GITHUB_REPOSITORY"))
           (cons 'build (getenv "GITHUB_RUN_ID"))

--- a/cover/private/github-service.rkt
+++ b/cover/private/github-service.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(provide github-service@ github-env?)
+
+(require "ci-service.rkt" racket/unit racket/list racket/string)
+
+(define (github-ci?) (and (getenv "GITHUB_REPOSITORY") (getenv "CODECOV_TOKEN")))
+
+(define-unit github-service@
+  (import)
+  (export ci-service^)
+
+  (define (query)
+    (define repo-slug (getenv "GITHUB_REPOSITORY"))
+    (list (cons 'service "custom")
+          (cons 'token (getenv "CODECOV_TOKEN"))
+          ;; TODO: this won't work for tags
+          (cons 'branch (substring (getenv "GITHUB_REF") (string-length "refs/heads/")))
+          (cons 'job (getenv "GITHUB_JOB"))
+          (cons 'slug (getenv "GITHUB_REPOSITORY"))
+          (cons 'build (getenv "GITHUB_RUN_ID"))
+          (cons 'commit (getenv "GITHUB_SHA")))))


### PR DESCRIPTION
This adds support for GitHub's CI "Github Actions" also sometimes called "GitHub Workflows".

I have used this branch successfully in the https://github.com/jsmaniac/anaphoric repository, as can be seen in the Codecov result https://app.codecov.io/gh/jsmaniac/anaphoric/

The environment variable CODECOV_TOKEN must be set (using a github secret as this token would probably allow anyone to update the code coverage result otherwise) as explained here https://stackoverflow.com/a/67998780/324969, even if the repository is public. The Codecov action on the GitHub Actions marketplace somehow works for public repositories without this token, but I was not able to understand how it does that, so until someone figures that out, the token is required :) .